### PR TITLE
Added brfs transform to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "devDependencies": {
     "tape": "^4.6.3"
   },
+  "browserify": {
+    "transform": ["brfs"]
+  },
   "scripts": {
     "test": "node test.js"
   },


### PR DESCRIPTION
This module isn't browserifying properly when included as a dependency (like in ` hyperdrive`) because the WASM file is loaded through `fs.readFileSync`. Even though `brfs` is already included, it wasn't being applied. This addition seems to fix the problem!
